### PR TITLE
fix/issue-31: Entra privileged roles queries

### DIFF
--- a/queries/All members of high privileged roles.yml
+++ b/queries/All members of high privileged roles.yml
@@ -6,7 +6,7 @@ category: General
 description: 
 query: |-
   MATCH p=(t:AZRole)<-[:AZHasRole|AZMemberOf*1..2]-(:AZBase)
-  WHERE t.name =~ '(?i)Global Administrator|User Administrator|Cloud Application Administrator|Authentication Policy Administrator|Exchange Administrator|Helpdesk Administrator|Privileged Authentication Administrator'
+  WHERE t.name =~ '(?i)Global Administrator|User Administrator|Cloud Application Administrator|Authentication Policy Administrator|Exchange Administrator|Helpdesk Administrator|Privileged Authentication Administrator|Privileged Role Administrator'
   RETURN p
   LIMIT 1000
 revision: 1

--- a/queries/All members of high privileged roles.yml
+++ b/queries/All members of high privileged roles.yml
@@ -9,7 +9,7 @@ query: |-
   WHERE t.name =~ '(?i)Global Administrator|User Administrator|Cloud Application Administrator|Authentication Policy Administrator|Exchange Administrator|Helpdesk Administrator|Privileged Authentication Administrator|Privileged Role Administrator'
   RETURN p
   LIMIT 1000
-revision: 1
+revision: 2
 resources: 
 acknowledgements: 
 

--- a/queries/Shortest paths from Entra Users to Tier Zero High Value targets.yml
+++ b/queries/Shortest paths from Entra Users to Tier Zero High Value targets.yml
@@ -6,8 +6,7 @@ category: Shortest Paths
 description: 
 query: |-
   MATCH p=shortestPath((s:AZUser)-[:AZ_ATTACK_PATHS*1..]->(t:AZBase))
-  WHERE (t:AZBase) AND t.name =~ '(?i)Global Administrator|User Administrator|Cloud Application Administrator|Authentication Policy Administrator|Exchange Administrator|Helpdesk Administrator|Privileged Authentication Administrator' AND s<>t
-  AND ((t:Tag_Tier_Zero) OR COALESCE(t.system_tags, '') CONTAINS 'admin_tier_0')
+  WHERE ((t:Tag_Tier_Zero) OR COALESCE(t.system_tags, '') CONTAINS 'admin_tier_0')
   RETURN p
   LIMIT 1000
 revision: 2

--- a/queries/Shortest paths from Entra Users to Tier Zero High Value targets.yml
+++ b/queries/Shortest paths from Entra Users to Tier Zero High Value targets.yml
@@ -9,7 +9,7 @@ query: |-
   WHERE ((t:Tag_Tier_Zero) OR COALESCE(t.system_tags, '') CONTAINS 'admin_tier_0')
   RETURN p
   LIMIT 1000
-revision: 2
+revision: 3
 resources: 
 acknowledgements: 
 

--- a/queries/Shortest paths to privileged roles.yml
+++ b/queries/Shortest paths to privileged roles.yml
@@ -9,7 +9,7 @@ query: |-
   WHERE t.name =~ '(?i)Global Administrator|User Administrator|Cloud Application Administrator|Authentication Policy Administrator|Exchange Administrator|Helpdesk Administrator|Privileged Authentication Administrator|Privileged Role Administrator' AND s<>t
   RETURN p
   LIMIT 1000
-revision: 2
+revision: 3
 resources: 
 acknowledgements: 
 

--- a/queries/Shortest paths to privileged roles.yml
+++ b/queries/Shortest paths to privileged roles.yml
@@ -6,7 +6,7 @@ category: Shortest Paths
 description: 
 query: |-
   MATCH p=shortestPath((s:AZBase)-[:AZ_ATTACK_PATHS*1..]->(t:AZRole))
-  WHERE t.name =~ '(?i)Global Administrator|User Administrator|Cloud Application Administrator|Authentication Policy Administrator|Exchange Administrator|Helpdesk Administrator|Privileged Authentication Administrator' AND s<>t
+  WHERE t.name =~ '(?i)Global Administrator|User Administrator|Cloud Application Administrator|Authentication Policy Administrator|Exchange Administrator|Helpdesk Administrator|Privileged Authentication Administrator|Privileged Role Administrator' AND s<>t
   RETURN p
   LIMIT 1000
 revision: 2


### PR DESCRIPTION
Addresses: https://github.com/SpecterOps/BloodHoundQueryLibrary/issues/31

Add condition for AZRole 'Privileged Role Administrator':
- Shortest paths to privileged roles (3dc73dd8-4873-4aeb-a88f-56a58c77f512)
- All members of high privileged roles (3df24d92-dd12-4125-811b-e696b098f60e)

Remove role condition for Tier Zero specific query:
- Shortest paths from Entra Users to Tier Zero / High Value targets (58089b28-54e0-4fd2-bf66-3db480b00e2f)