### PR TITLE
Add gMSA Cypher queries for BloodHound CE

### DIFF
--- a/queries/All ReadGMSAPassword relationships.yml
+++ b/queries/All ReadGMSAPassword relationships.yml
@@ -1,0 +1,12 @@
+name: All ReadGMSAPassword relationships
+guid: bf6c0ed5-c9dd-4c4b-a8ca-7c0f30bed596
+prebuilt: false
+platforms: Active Directory
+category: Dangerous Privileges
+description: Show all ReadGMSAPassword relationships as paths, revealing which principals can read gMSA passwords.
+query: |-
+  MATCH p=()-[:ReadGMSAPassword]->()
+  RETURN p
+revision: 1
+resources:
+acknowledgements: chryzsh

--- a/queries/All gMSAs.yml
+++ b/queries/All gMSAs.yml
@@ -1,0 +1,12 @@
+name: All gMSAs
+guid: 0fc16935-14b7-4859-9a2a-a191daa4c081
+prebuilt: false
+platforms: Active Directory
+category: Dangerous Privileges
+description: List all Group Managed Service Accounts (gMSAs) by finding nodes targeted by ReadGMSAPassword relationships.
+query: |-
+  MATCH ()-[:ReadGMSAPassword]->(g)
+  RETURN g
+revision: 1
+resources:
+acknowledgements: chryzsh

--- a/queries/Effective gMSA password readers through group membership.yml
+++ b/queries/Effective gMSA password readers through group membership.yml
@@ -1,0 +1,12 @@
+name: Effective gMSA password readers through group membership
+guid: 026f5115-fb0d-423e-926e-5a1401154c27
+prebuilt: false
+platforms: Active Directory
+category: Dangerous Privileges
+description: Find principals that can effectively read gMSA passwords through nested group memberships.
+query: |-
+  MATCH p=(m)-[:MemberOf*1..]->(g)-[:ReadGMSAPassword]->()
+  RETURN p
+revision: 1
+resources:
+acknowledgements: chryzsh

--- a/queries/Principals with ReadGMSAPassword.yml
+++ b/queries/Principals with ReadGMSAPassword.yml
@@ -1,0 +1,12 @@
+name: Principals with ReadGMSAPassword
+guid: 10d0ee8e-17ec-4f6c-9b94-8dffe548f9d4
+prebuilt: false
+platforms: Active Directory
+category: Dangerous Privileges
+description: Show each principal that can read a gMSA password alongside the target gMSA account.
+query: |-
+  MATCH (a)-[:ReadGMSAPassword]->(b)
+  RETURN a, b
+revision: 1
+resources:
+acknowledgements: chryzsh


### PR DESCRIPTION
Add four queries for enumerating and analyzing Group Managed Service Accounts (gMSAs) and ReadGMSAPassword relationships:

- All gMSAs: List all gMSA accounts
- All ReadGMSAPassword relationships: Show all ReadGMSAPassword edges
- Principals with ReadGMSAPassword: Reader and target pairs
- Effective gMSA password readers through group membership: Nested group traversal