### PR TITLE
Computers with local administrator permissions over other computers

### DIFF
--- a/queries/Computers with local administrator permissions over other computers.yml
+++ b/queries/Computers with local administrator permissions over other computers.yml
@@ -1,0 +1,16 @@
+name: Computers with local administrator permissions over other computers
+guid: 093a8e04-4f79-4264-a64b-4e52a630cd0d
+prebuilt: false 
+platform: Active Directory 
+category: NTLM Relay Attacks
+description: Finds computers with AdminTo edges over other computers, including rights derived through nested group memberships.
+query: |-
+  MATCH p = (s:Computer)-[:MemberOf*0..]->()-[:AdminTo]->(d:Computer)
+  WHERE s <> d
+  RETURN p
+  LIMIT 1000
+revision: 1
+resources:  
+ - https://specterops.io/blog/2025/04/08/the-renaissance-of-ntlm-relay-attacks-everything-you-need-to-know/
+ - https://github.com/subat0mik/Misconfiguration-Manager
+acknowledgements: Mat Fiore, @stuk0v

--- a/queries/Computers with local administrator permissions over other computers.yml
+++ b/queries/Computers with local administrator permissions over other computers.yml
@@ -13,4 +13,4 @@ revision: 1
 resources:  
  - https://specterops.io/blog/2025/04/08/the-renaissance-of-ntlm-relay-attacks-everything-you-need-to-know/
  - https://github.com/subat0mik/Misconfiguration-Manager
-acknowledgements: Mat Fiore, @stuk0v
+acknowledgements: @stuk0v_


### PR DESCRIPTION
Added a query that I use often: `Computers with local administrator permissions over other computers.yml` to find computers with "AdminTo" edges over other computers, including nested group memberships.