### PR TITLE
Add "non-tier-zero shortest path to tier zero" queries

### DIFF
--- a/queries/Shortest paths from non-Tier Zero computers to Tier Zero.yml
+++ b/queries/Shortest paths from non-Tier Zero computers to Tier Zero.yml
@@ -1,0 +1,17 @@
+name: Shortest paths from non-Tier Zero computers to Tier Zero
+guid: 004374c9-4a81-4884-9837-c75dad71fa83
+prebuilt: false
+platforms: Active Directory
+category: Shortest Paths
+description: WARNING! MANY-TO-MANY SHORTEST PATH QUERIES USE EXCESSIVE SYSTEM RESOURCES AND TYPICALLY WILL NOT COMPLETE
+query: |-
+  // MANY TO MANY SHORTEST PATH QUERIES USE EXCESSIVE SYSTEM RESOURCES AND TYPICALLY WILL NOT COMPLETE
+  MATCH p=shortestPath((s:Computer)-[:AD_ATTACK_PATHS*1..]->(t:Base))
+  WHERE s<>t
+  AND NOT ((s:Tag_Tier_Zero) OR COALESCE(s.system_tags, '') CONTAINS 'admin_tier_0')
+  AND ((t:Tag_Tier_Zero) OR COALESCE(t.system_tags, '') CONTAINS 'admin_tier_0')
+  RETURN p
+  LIMIT 1000
+revision: 1
+resources: 
+acknowledgements: 

--- a/queries/Shortest paths from non-Tier Zero groups to Tier Zero.yml
+++ b/queries/Shortest paths from non-Tier Zero groups to Tier Zero.yml
@@ -1,0 +1,17 @@
+name: Shortest paths from non-Tier Zero groups to Tier Zero
+guid: 0ac20b7a-31df-4f3a-b2bd-3eecd541fcaa
+prebuilt: false
+platforms: Active Directory
+category: Shortest Paths
+description: WARNING! MANY-TO-MANY SHORTEST PATH QUERIES USE EXCESSIVE SYSTEM RESOURCES AND TYPICALLY WILL NOT COMPLETE
+query: |-
+  // MANY TO MANY SHORTEST PATH QUERIES USE EXCESSIVE SYSTEM RESOURCES AND TYPICALLY WILL NOT COMPLETE
+  MATCH p=shortestPath((s:Group)-[:AD_ATTACK_PATHS*1..]->(t:Base))
+  WHERE s<>t
+  AND NOT ((s:Tag_Tier_Zero) OR COALESCE(s.system_tags, '') CONTAINS 'admin_tier_0')
+  AND ((t:Tag_Tier_Zero) OR COALESCE(t.system_tags, '') CONTAINS 'admin_tier_0')
+  RETURN p
+  LIMIT 1000
+revision: 1
+resources: 
+acknowledgements: 

--- a/queries/Shortest paths from non-Tier Zero objects to Tier Zero.yml
+++ b/queries/Shortest paths from non-Tier Zero objects to Tier Zero.yml
@@ -1,0 +1,17 @@
+name: Shortest paths from non-Tier Zero objects to Tier Zero
+guid: 47845724-94bc-4b68-944b-1114d230fc0c
+prebuilt: false
+platforms: Active Directory
+category: Shortest Paths
+description: WARNING! MANY-TO-MANY SHORTEST PATH QUERIES USE EXCESSIVE SYSTEM RESOURCES AND TYPICALLY WILL NOT COMPLETE
+query: |-
+  // MANY TO MANY SHORTEST PATH QUERIES USE EXCESSIVE SYSTEM RESOURCES AND TYPICALLY WILL NOT COMPLETE
+  MATCH p=shortestPath((s:Base)-[:AD_ATTACK_PATHS*1..]->(t:Base))
+  WHERE s<>t
+  AND NOT ((s:Tag_Tier_Zero) OR COALESCE(s.system_tags, '') CONTAINS 'admin_tier_0')
+  AND ((t:Tag_Tier_Zero) OR COALESCE(t.system_tags, '') CONTAINS 'admin_tier_0')
+  RETURN p
+  LIMIT 1000
+revision: 1
+resources: 
+acknowledgements: 

--- a/queries/Shortest paths from non-Tier Zero user accounts to Tier Zero.yml
+++ b/queries/Shortest paths from non-Tier Zero user accounts to Tier Zero.yml
@@ -1,0 +1,17 @@
+name: Shortest paths from non-Tier Zero user accounts to Tier Zero
+guid: 8b61bf34-5256-47e5-a5a8-370e8ddc3f90
+prebuilt: false
+platforms: Active Directory
+category: Shortest Paths
+description: WARNING! MANY-TO-MANY SHORTEST PATH QUERIES USE EXCESSIVE SYSTEM RESOURCES AND TYPICALLY WILL NOT COMPLETE
+query: |-
+  // MANY TO MANY SHORTEST PATH QUERIES USE EXCESSIVE SYSTEM RESOURCES AND TYPICALLY WILL NOT COMPLETE
+  MATCH p=shortestPath((s:User)-[:AD_ATTACK_PATHS*1..]->(t:Base))
+  WHERE s<>t
+  AND NOT ((s:Tag_Tier_Zero) OR COALESCE(s.system_tags, '') CONTAINS 'admin_tier_0')
+  AND ((t:Tag_Tier_Zero) OR COALESCE(t.system_tags, '') CONTAINS 'admin_tier_0')
+  RETURN p
+  LIMIT 1000
+revision: 1
+resources: 
+acknowledgements: 


### PR DESCRIPTION
We found that breaking down paths to Tier Zero by source type makes sense during testing and helps vizualise specific attacks paths to Tier Zero in reporting. We found them to be a good alternative to the built-in "Shortest paths to Tier Zero / High Value targets" query, which doesn't exclude Tier Zero to Tier Zero paths. Each query filters sources that are NOT Tier Zero and targets that ARE Tier Zero using both Tag_Tier_Zero labels and system_tags.

- Shortest paths from non-Tier Zero computers to Tier Zero
- Shortest paths from non-Tier Zero groups to Tier Zero
- Shortest paths from non-Tier Zero objects to Tier Zero
- Shortest paths from non-Tier Zero user accounts to Tier Zero