### PR TITLE
Add AIHound cypher queries for AI credential and service attack path analysis

### DIFF
--- a/queries/AIHound - Blast Radius - Critical credentials (up to 4 hops).yml
+++ b/queries/AIHound - Blast Radius - Critical credentials (up to 4 hops).yml
@@ -1,0 +1,13 @@
+name: AIHound - Blast Radius - Critical credentials (up to 4 hops)
+guid: 0c98dad6-0d7a-4379-aae4-8e4ad38aea95
+prebuilt: false
+platforms: 
+category: AIHound
+description: All nodes reachable from critical credentials (up to 4 hops). Shows what's exposed if a critical credential leaks.
+query: |-
+  MATCH path = (c:AIHound_AICredential)-[*1..4]->(target)
+  WHERE c.risk_level = "critical"
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Blast Radius - From a specific file.yml
+++ b/queries/AIHound - Blast Radius - From a specific file.yml
@@ -1,0 +1,13 @@
+name: AIHound - Blast Radius - From a specific file
+guid: e311f703-382c-40e7-8162-946d9301d3ca
+prebuilt: false
+platforms: 
+category: AIHound
+description: Blast radius from a specific config file (edit the CONTAINS filter to match your file).
+query: |-
+  MATCH path = (f:AIHound_ConfigFile)-[:AIHound_ContainsCredential]->(c:AIHound_AICredential)-[*1..3]->(target)
+  WHERE f.path CONTAINS ".credentials.json"
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Credential Chain - All credentials and their services.yml
+++ b/queries/AIHound - Credential Chain - All credentials and their services.yml
@@ -1,0 +1,12 @@
+name: AIHound - Credential Chain - All credentials and their services
+guid: 069135c2-6cf0-49a2-b75d-07b45114cb41
+prebuilt: false
+platforms: 
+category: AIHound
+description: All credentials and the services they authenticate to.
+query: |-
+  MATCH path = (c:AIHound_AICredential)-[:AIHound_Authenticates]->(s:AIHound_AIService)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Credential Chain - Credentials to services to data stores.yml
+++ b/queries/AIHound - Credential Chain - Credentials to services to data stores.yml
@@ -1,0 +1,12 @@
+name: AIHound - Credential Chain - Credentials to services to data stores
+guid: d68d7521-19f5-4d29-a4ba-a8f914b89894
+prebuilt: false
+platforms: 
+category: AIHound
+description: Full attack chain from credentials through services to data stores.
+query: |-
+  MATCH path = (c:AIHound_AICredential)-[:AIHound_Authenticates]->(s:AIHound_AIService)-[:AIHound_GrantsAccessTo]->(d:AIHound_DataStore)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Credential Chain - Critical and high risk credentials with services.yml
+++ b/queries/AIHound - Credential Chain - Critical and high risk credentials with services.yml
@@ -1,0 +1,13 @@
+name: AIHound - Credential Chain - Critical and high risk credentials with services
+guid: 270e9cd2-97a6-4b7f-b775-0bf8f188e2bb
+prebuilt: false
+platforms: 
+category: AIHound
+description: Critical and high risk credentials with their authenticated services.
+query: |-
+  MATCH path = (c:AIHound_AICredential)-[:AIHound_Authenticates]->(s:AIHound_AIService)
+  WHERE c.risk_level = "critical" OR c.risk_level = "high"
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Credential Rotation - All MCP server credential dependencies.yml
+++ b/queries/AIHound - Credential Rotation - All MCP server credential dependencies.yml
@@ -1,0 +1,12 @@
+name: AIHound - Credential Rotation - All MCP server credential dependencies
+guid: 29f34ccb-6e43-42c0-b45b-46261fa36971
+prebuilt: false
+platforms: 
+category: AIHound
+description: All MCP servers and the credentials they depend on.
+query: |-
+  MATCH path = (m:AIHound_MCPServer)-[:AIHound_RequiresCredential]->(c:AIHound_AICredential)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Credential Rotation - PERPLEXITY key dependencies.yml
+++ b/queries/AIHound - Credential Rotation - PERPLEXITY key dependencies.yml
@@ -1,0 +1,13 @@
+name: AIHound - Credential Rotation - PERPLEXITY key dependencies
+guid: 6c45a453-84bf-4baa-a3d6-05e539ca3d6c
+prebuilt: false
+platforms: 
+category: AIHound
+description: What breaks if you rotate a PERPLEXITY API key (tool → MCP server → credential dependencies).
+query: |-
+  MATCH path = (t:AIHound_AITool)-[:AIHound_UsesMCPServer]->(m:AIHound_MCPServer)-[:AIHound_RequiresCredential]->(c:AIHound_AICredential)
+  WHERE c.credential_type CONTAINS "PERPLEXITY"
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Cross-Tool - Different tools authenticating to same service.yml
+++ b/queries/AIHound - Cross-Tool - Different tools authenticating to same service.yml
@@ -1,0 +1,14 @@
+name: AIHound - Cross-Tool - Different tools authenticating to same service
+guid: 222d71d7-72c1-4780-9aa2-f676f16bf05f
+prebuilt: false
+platforms: 
+category: AIHound
+description: Multiple tools that authenticate to the same service (credential sprawl across tools).
+query: |-
+  MATCH path1 = (c1:AIHound_AICredential)-[:AIHound_Authenticates]->(s:AIHound_AIService),
+        path2 = (c2:AIHound_AICredential)-[:AIHound_Authenticates]->(s)
+  WHERE c1.tool <> c2.tool
+  RETURN path1, path2
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Docker Credentials - Docker configs and contents.yml
+++ b/queries/AIHound - Docker Credentials - Docker configs and contents.yml
@@ -1,0 +1,12 @@
+name: AIHound - Docker Credentials - Docker configs and contents
+guid: 0eeaaaca-9eee-42f0-b9b4-5b961c28d30a
+prebuilt: false
+platforms: 
+category: AIHound
+description: Docker configuration files and the credentials they contain.
+query: |-
+  MATCH path = (d:AIHound_DockerConfig)-[:AIHound_ContainsCredential]->(c:AIHound_AICredential)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - File Compromise - .claude.json contents to services.yml
+++ b/queries/AIHound - File Compromise - .claude.json contents to services.yml
@@ -1,0 +1,13 @@
+name: AIHound - File Compromise - .claude.json contents to services
+guid: c27d5822-7225-4802-b9ce-46a4d699d4b1
+prebuilt: false
+platforms: 
+category: AIHound
+description: What services are exposed if .claude.json is compromised.
+query: |-
+  MATCH path = (f:AIHound_ConfigFile)-[:AIHound_ContainsCredential]->(c:AIHound_AICredential)-[:AIHound_Authenticates]->(s:AIHound_AIService)
+  WHERE f.path CONTAINS ".claude.json"
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - File Compromise - .credentials.json contents to services.yml
+++ b/queries/AIHound - File Compromise - .credentials.json contents to services.yml
@@ -1,0 +1,13 @@
+name: AIHound - File Compromise - .credentials.json contents to services
+guid: 14c9cc04-ff8a-4c7a-be0e-7692c370b9fa
+prebuilt: false
+platforms: 
+category: AIHound
+description: What services are exposed if .credentials.json is compromised.
+query: |-
+  MATCH path = (f:AIHound_ConfigFile)-[:AIHound_ContainsCredential]->(c:AIHound_AICredential)-[:AIHound_Authenticates]->(s:AIHound_AIService)
+  WHERE f.path CONTAINS ".credentials.json"
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - File Compromise - Tool to file to credential to service chain.yml
+++ b/queries/AIHound - File Compromise - Tool to file to credential to service chain.yml
@@ -1,0 +1,12 @@
+name: AIHound - File Compromise - Tool to file to credential to service chain
+guid: 250f1231-bc17-4c57-bd27-162a1a3f2bf1
+prebuilt: false
+platforms: 
+category: AIHound
+description: Full read chain: which tools read which files, what credentials are in them, and what services they unlock.
+query: |-
+  MATCH path = (t:AIHound_AITool)-[:AIHound_ReadsFrom]->(f:AIHound_ConfigFile)-[:AIHound_ContainsCredential]->(c:AIHound_AICredential)-[:AIHound_Authenticates]->(s:AIHound_AIService)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Full Graph - All nodes and edges.yml
+++ b/queries/AIHound - Full Graph - All nodes and edges.yml
@@ -1,0 +1,12 @@
+name: AIHound - Full Graph - All nodes and edges
+guid: 6193c604-5eca-42aa-a5a0-6642d6143edc
+prebuilt: false
+platforms: 
+category: AIHound
+description: All AIHound nodes and edges — best for screenshots. START HERE.
+query: |-
+  MATCH path = (a:AIHound)-[r]->(b:AIHound)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Git Credentials - Git credential contents.yml
+++ b/queries/AIHound - Git Credentials - Git credential contents.yml
@@ -1,0 +1,12 @@
+name: AIHound - Git Credentials - Git credential contents
+guid: c8e7b8d7-2f04-4740-a50a-9bc6f616193b
+prebuilt: false
+platforms: 
+category: AIHound
+description: Git credential files and the credentials they contain.
+query: |-
+  OPTIONAL MATCH path = (g:AIHound_GitCredential)-[:AIHound_ContainsCredential]->(c:AIHound_AICredential)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - MCP Server Attack Chains - Extended chain through to services.yml
+++ b/queries/AIHound - MCP Server Attack Chains - Extended chain through to services.yml
@@ -1,0 +1,12 @@
+name: AIHound - MCP Server Attack Chains - Extended chain through to services
+guid: 35bd7df6-3188-424c-96ec-5397913437a8
+prebuilt: false
+platforms: 
+category: AIHound
+description: Extended MCP chain: tool → MCP server → credential → service.
+query: |-
+  MATCH path = (t:AIHound_AITool)-[:AIHound_UsesMCPServer]->(m:AIHound_MCPServer)-[:AIHound_RequiresCredential]->(c:AIHound_AICredential)-[:AIHound_Authenticates]->(s:AIHound_AIService)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - MCP Server Attack Chains - Tool to MCP to credential.yml
+++ b/queries/AIHound - MCP Server Attack Chains - Tool to MCP to credential.yml
@@ -1,0 +1,12 @@
+name: AIHound - MCP Server Attack Chains - Tool to MCP to credential
+guid: 80c8a494-b0f5-4be7-8830-fd8f2fe35e4c
+prebuilt: false
+platforms: 
+category: AIHound
+description: MCP server chain: which tools use which MCP servers and what credentials those servers need.
+query: |-
+  MATCH path = (t:AIHound_AITool)-[:AIHound_UsesMCPServer]->(m:AIHound_MCPServer)-[:AIHound_RequiresCredential]->(c:AIHound_AICredential)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Network Attack Surface - Unauthenticated AI services.yml
+++ b/queries/AIHound - Network Attack Surface - Unauthenticated AI services.yml
@@ -1,0 +1,12 @@
+name: AIHound - Network Attack Surface - Unauthenticated AI services
+guid: c092a241-cb89-422a-b752-91ce33dad65f
+prebuilt: false
+platforms: 
+category: AIHound
+description: Network-exposed AI services (Ollama, LM Studio, Jupyter on 0.0.0.0). Only returns results if exposed services were found.
+query: |-
+  OPTIONAL MATCH path = (n:AIHound_NetworkEndpoint)-[:AIHound_ExposesService]->(s:AIHound_AIService)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Overly Permissive Files - Critical credentials and their files.yml
+++ b/queries/AIHound - Overly Permissive Files - Critical credentials and their files.yml
@@ -1,0 +1,13 @@
+name: AIHound - Overly Permissive Files - Critical credentials and their files
+guid: 6b913158-349f-4295-be67-943c27922c64
+prebuilt: false
+platforms: 
+category: AIHound
+description: Critical credentials and the files they're stored in.
+query: |-
+  MATCH path = (c:AIHound_AICredential)-[:AIHound_StoredIn]->(f:AIHound_ConfigFile)
+  WHERE c.risk_level = "critical"
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Overly Permissive Files - Non-0600 permissions.yml
+++ b/queries/AIHound - Overly Permissive Files - Non-0600 permissions.yml
@@ -1,0 +1,13 @@
+name: AIHound - Overly Permissive Files - Non-0600 permissions
+guid: ddeea7ae-e288-403f-88d1-2f0d91d3cafa
+prebuilt: false
+platforms: 
+category: AIHound
+description: Credentials stored in files with permissions other than 0600 (owner-only read/write).
+query: |-
+  MATCH path = (c:AIHound_AICredential)-[:AIHound_StoredIn]->(f:AIHound_ConfigFile)
+  WHERE c.file_permissions IS NOT NULL AND NOT c.file_permissions = "0600"
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Same Secret Sprawl - Credentials linked by SameSecret.yml
+++ b/queries/AIHound - Same Secret Sprawl - Credentials linked by SameSecret.yml
@@ -1,0 +1,12 @@
+name: AIHound - Same Secret Sprawl - Credentials linked by SameSecret
+guid: 6d0350cc-901e-4125-9595-5c56cb3116f8
+prebuilt: false
+platforms: 
+category: AIHound
+description: Credentials that share the same secret value (same key in multiple places).
+query: |-
+  MATCH path = (c1:AIHound_AICredential)-[:AIHound_SameSecret]->(c2:AIHound_AICredential)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Same Secret Sprawl - With storage locations.yml
+++ b/queries/AIHound - Same Secret Sprawl - With storage locations.yml
@@ -1,0 +1,14 @@
+name: AIHound - Same Secret Sprawl - With storage locations
+guid: cea6ffbb-6a60-452b-9a12-86a54869921b
+prebuilt: false
+platforms: 
+category: AIHound
+description: Same secret sprawl with the files where each copy is stored.
+query: |-
+  MATCH path1 = (c1:AIHound_AICredential)-[:AIHound_SameSecret]->(c2:AIHound_AICredential),
+        path2 = (c1)-[:AIHound_StoredIn]->(f1:AIHound_ConfigFile),
+        path3 = (c2)-[:AIHound_StoredIn]->(f2:AIHound_ConfigFile)
+  RETURN path1, path2, path3
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Shell History - Shell history credential chains.yml
+++ b/queries/AIHound - Shell History - Shell history credential chains.yml
@@ -1,0 +1,12 @@
+name: AIHound - Shell History - Shell history credential chains
+guid: fb16f459-49f4-496f-8f52-35600906c839
+prebuilt: false
+platforms: 
+category: AIHound
+description: Credentials leaked in shell history files and the services they authenticate to.
+query: |-
+  OPTIONAL MATCH path = (h:AIHound_ShellHistory)-[:AIHound_ContainsCredential]->(c:AIHound_AICredential)-[:AIHound_Authenticates]->(s:AIHound_AIService)
+  RETURN path
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Table - All critical credentials with remediation.yml
+++ b/queries/AIHound - Table - All critical credentials with remediation.yml
@@ -1,0 +1,14 @@
+name: AIHound - Table - All critical credentials with remediation
+guid: 16a1b477-b408-4b80-88c0-e83a73413983
+prebuilt: false
+platforms: 
+category: AIHound
+description: All critical-risk credentials with tool, location, permissions, and remediation steps. Use BloodHound's table view toggle.
+query: |-
+  MATCH (c:AIHound_AICredential)
+  WHERE c.risk_level = "critical"
+  RETURN c.name AS credential, c.tool AS tool, c.location AS location,
+         c.file_permissions AS permissions, c.remediation AS fix
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Table - Credentials with expiry dates.yml
+++ b/queries/AIHound - Table - Credentials with expiry dates.yml
@@ -1,0 +1,13 @@
+name: AIHound - Table - Credentials with expiry dates
+guid: ee810481-591f-4703-881f-69139411949f
+prebuilt: false
+platforms: 
+category: AIHound
+description: Credentials that have expiry dates. Use BloodHound's table view toggle.
+query: |-
+  MATCH (c:AIHound_AICredential)
+  WHERE c.expiry IS NOT NULL
+  RETURN c.name AS credential, c.tool AS tool, c.expiry AS expires
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Table - Most dangerous files by credential count.yml
+++ b/queries/AIHound - Table - Most dangerous files by credential count.yml
@@ -1,0 +1,13 @@
+name: AIHound - Table - Most dangerous files by credential count
+guid: 5dfb5639-7801-46ed-a4b2-497a283a6da8
+prebuilt: false
+platforms: 
+category: AIHound
+description: Files ranked by number of credentials they contain. Use BloodHound's table view toggle.
+query: |-
+  MATCH (f:AIHound_ConfigFile)-[:AIHound_ContainsCredential]->(c:AIHound_AICredential)
+  RETURN f.path AS file, f.file_permissions AS permissions, COUNT(c) AS credential_count
+  ORDER BY credential_count DESC
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Table - Node type counts.yml
+++ b/queries/AIHound - Table - Node type counts.yml
@@ -1,0 +1,13 @@
+name: AIHound - Table - Node type counts
+guid: 46ae836c-a65b-4e23-a299-1f1c952a0f91
+prebuilt: false
+platforms: 
+category: AIHound
+description: Count of each AIHound node type. Use BloodHound's table view toggle.
+query: |-
+  MATCH (n:AIHound)
+  RETURN n.primarykind AS node_type, COUNT(n) AS count
+  ORDER BY count DESC
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Table - Overly permissive files (detailed).yml
+++ b/queries/AIHound - Table - Overly permissive files (detailed).yml
@@ -1,0 +1,15 @@
+name: AIHound - Table - Overly permissive files (detailed)
+guid: 951ce7d9-98cb-44f8-afde-72075171d4ed
+prebuilt: false
+platforms: 
+category: AIHound
+description: Files with non-0600 permissions and their credential details. Use BloodHound's table view toggle.
+query: |-
+  MATCH (f:AIHound_ConfigFile)-[:AIHound_ContainsCredential]->(c:AIHound_AICredential)
+  WHERE c.file_permissions IS NOT NULL AND NOT c.file_permissions = "0600"
+  RETURN f.path AS file, c.name AS credential,
+         c.file_permissions AS permissions, c.risk_level AS risk
+  ORDER BY c.risk_level
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Table - Risk distribution.yml
+++ b/queries/AIHound - Table - Risk distribution.yml
@@ -1,0 +1,13 @@
+name: AIHound - Table - Risk distribution
+guid: 2e376803-f273-4d96-89a1-6381679c3622
+prebuilt: false
+platforms: 
+category: AIHound
+description: Count of credentials by risk level. Use BloodHound's table view toggle.
+query: |-
+  MATCH (c:AIHound_AICredential)
+  RETURN c.risk_level AS risk, COUNT(c) AS count
+  ORDER BY count DESC
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred

--- a/queries/AIHound - Table - Services by credential exposure.yml
+++ b/queries/AIHound - Table - Services by credential exposure.yml
@@ -1,0 +1,14 @@
+name: AIHound - Table - Services by credential exposure
+guid: 007ade97-03d2-4d5b-8163-4734f6f28d3c
+prebuilt: false
+platforms: 
+category: AIHound
+description: Services ranked by number of credentials that authenticate to them. Use BloodHound's table view toggle.
+query: |-
+  MATCH (c:AIHound_AICredential)-[:AIHound_Authenticates]->(s:AIHound_AIService)
+  RETURN s.name AS service, COUNT(c) AS credentials,
+         COLLECT(DISTINCT c.risk_level) AS risk_levels
+  ORDER BY credentials DESC
+revision: 1
+resources: https://github.com/netwrix/AIHound
+acknowledgements: AIHound, DFIRDeferred


### PR DESCRIPTION
## Summary
  - Adds 29 community cypher queries for use with [AIHound](https://github.com/netwrix/AIHound), a tool that maps
  AI credentials, services, and configurations into BloodHound's graph database
  - Queries cover attack path analysis for AI tool credential sprawl, MCP server chains, file compromise blast
  radius, secret reuse, network-exposed AI services, and tabular reporting views
  - Categories include: full graph visualization, blast radius, credential chains, file compromise, overly
  permissive files, MCP server attack chains, same secret sprawl, credential rotation impact, cross-tool exposure,
  Docker/Git/shell history credentials, and network attack surface

## Test plan
  - [ ] Import AIHound data into BloodHound CE
  - [ ] Load each query via the custom queries panel
  - [ ] Verify graph and table queries return expected results against sample data