### PR TITLE
Deploy query releases to GitHub Pages and enforce UTF-8 reports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,11 @@ jobs:
 
 
   release:
+    if: github.repository == 'SpecterOps/BloodHoundQueryLibrary'
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.10
@@ -56,6 +59,16 @@ jobs:
       - name: Convert queries into single json file
         run: |
           python utilities/python/convert.py ./queries ./Queries.json
+
+      - name: Stage GitHub Pages site
+        run: |
+          mkdir pages
+          cp Queries.json pages/Queries.json
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: pages
       
       - name: Set metadata
         id: release_meta
@@ -76,3 +89,17 @@ jobs:
           body: | 
             This release contains all queries exported as JSON and bundled in a single file. The compressed .zip file can be uploaded to BloodHound to bulk-import all queries.
           draft: true
+
+  deploy-pages:
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ class GithubReporter:
         )
         template = env.get_template("githubsummary.md.j2")
         rendered = template.render(data=self.results)
-        with open("test-report.md", "w") as f:
+        with open("test-report.md", "w", encoding="utf-8") as f:
             f.write(rendered)
 
 


### PR DESCRIPTION
## Summary

- Write `test-report.md` explicitly as UTF-8 to handle non-ASCII query content consistently.
- Upload the generated `Queries.json` as a GitHub Pages artifact.
- Deploy the artifact after the test and release jobs succeed.
- Restrict release publishing to the upstream `SpecterOps/BloodHoundQueryLibrary` repository.
- Grant each job only the permissions required for releases and Pages deployment.

## Motivation

queries.specterops.io loads the catalog from:

`https://specterops.github.io/BloodHoundQueryLibrary/Queries.json`

The release workflow generated an up-to-date `Queries.json` for GitHub releases, but did not update the Pages copy. This caused queries.specterops.io to use an older query catalog.

Explicit UTF-8 output also prevents test-report generation from depending on the runner's default encoding.

## Expected behavior

After a successful push to `main`:

1. Query validation completes.
2. `Queries.json` and `Queries.zip` are generated for the draft release.
3. The same `Queries.json` is uploaded and deployed to GitHub Pages.
4. queries.specterops.io receives the current catalog from its existing source URL.

Release and deployment jobs are skipped in forks. No query definitions or platform behavior are changed.

## Testing

- `git diff --check` passes.
- Query syntax validation will run on this PR.
- The production Pages deployment can be verified after merge by comparing the number of objects in the published `Queries.json` with the YAML files under `queries/`.

## Deployment note

GitHub Pages is configured to use **GitHub Actions** as its publishing source.